### PR TITLE
Prevent listUnspent from blocking the UI thread

### DIFF
--- a/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
+++ b/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
@@ -452,17 +452,19 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun listUnspent(id: String, result: Promise) {
         try {
-            val unspentList = getWalletById(id).listUnspent()
-            val unpents: MutableList<Map<String, Any?>> = mutableListOf()
-            for (item in unspentList) {
-                val unspentObject = mutableMapOf<String, Any?>()
-                unspentObject["outpoint"] = getOutPoint(item.outpoint)
-                unspentObject["txout"] = createTxOut(item.txout, _scripts)
-                unspentObject["isSpent"] = item.isSpent
-                unspentObject["keychain"] = item.keychain.toString()
-                unpents.add(unspentObject)
-            }
-            result.resolve(Arguments.makeNativeArray(unpents))
+            Thread {
+                val unspentList = getWalletById(id).listUnspent()
+                val unpents: MutableList<Map<String, Any?>> = mutableListOf()
+                for (item in unspentList) {
+                    val unspentObject = mutableMapOf<String, Any?>()
+                    unspentObject["outpoint"] = getOutPoint(item.outpoint)
+                    unspentObject["txout"] = createTxOut(item.txout, _scripts)
+                    unspentObject["isSpent"] = item.isSpent
+                    unspentObject["keychain"] = item.keychain.toString()
+                    unpents.add(unspentObject)
+                }
+                result.resolve(Arguments.makeNativeArray(unpents))
+            }.start()
         } catch (error: Throwable) {
             result.reject("List unspent outputs error", error.localizedMessage, error)
         }


### PR DESCRIPTION
I found that using `listUnspent` is blocking the UI thread.

Wrapping it in a `Thread` block solves the issue.

At this point I am wondering which other methods would benefit from moving the execution into a separate thread. Maybe all of them?