### PR TITLE
Bugfix/prevent crash address as string

### DIFF
--- a/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
+++ b/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
@@ -369,20 +369,20 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun sync(id: String, blockChainId: String, result: Promise) {
-        try {
-            Thread {
+        Thread {
+            try {
                 getWalletById(id).sync(getBlockchainById(blockChainId), BdkProgress)
                 result.resolve(true)
-            }.start()
-        } catch (error: Throwable) {
-            result.reject("Sync wallet error", error.localizedMessage, error)
-        }
+            } catch (error: Throwable) {
+                result.reject("Sync wallet error", error.localizedMessage, error)
+            }
+        }.start()
     }
 
     @ReactMethod
     fun getAddress(id: String, addressIndex: String, result: Promise) {
-        try {
-            Thread {
+        Thread {
+            try {
                 val randomId = randomId()
                 val addressInfo = getWalletById(id).getAddress(setAddressIndex(addressIndex))
                 _addresses[randomId] = addressInfo.address
@@ -391,16 +391,16 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
                 responseObject["address"] = randomId
                 responseObject["keychain"] = addressInfo.keychain.toString()
                 result.resolve(Arguments.makeNativeMap(responseObject))
-            }.start()
-        } catch (error: Throwable) {
-            result.reject("Get wallet address error", error.localizedMessage, error)
-        }
+            } catch (error: Throwable) {
+                result.reject("Get wallet address error", error.localizedMessage, error)
+            }
+        }.start()
     }
 
     @ReactMethod
     fun getInternalAddress(id: String, addressIndex: String, result: Promise) {
-        try {
-            Thread {
+        Thread {
+            try {
                 val randomId = randomId()
                 val addressInfo =
                     getWalletById(id).getInternalAddress(setAddressIndex(addressIndex))
@@ -410,10 +410,10 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
                 responseObject["address"] = randomId
                 responseObject["keychain"] = addressInfo.keychain.toString()
                 result.resolve(Arguments.makeNativeMap(responseObject))
-            }.start()
-        } catch (error: Throwable) {
-            result.reject("Get internal address error", error.localizedMessage, error)
-        }
+            } catch (error: Throwable) {
+                result.reject("Get internal address error", error.localizedMessage, error)
+            }
+        }.start()
     }
 
     @ReactMethod
@@ -427,8 +427,8 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getBalance(id: String, result: Promise) {
-        try {
-            Thread {
+        Thread {
+            try {
                 val balance = getWalletById(id).getBalance()
                 val responseObject = mutableMapOf<String, Any?>()
                 responseObject["trustedPending"] = balance.trustedPending.toInt()
@@ -437,10 +437,10 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
                 responseObject["spendable"] = balance.spendable.toInt()
                 responseObject["total"] = balance.total.toInt()
                 result.resolve(Arguments.makeNativeMap(responseObject))
-            }.start()
-        } catch (error: Throwable) {
-            result.reject("Get wallet balance error", error.localizedMessage, error)
-        }
+            } catch (error: Throwable) {
+                result.reject("Get wallet balance error", error.localizedMessage, error)
+            }
+        }.start()
     }
 
     @ReactMethod
@@ -451,8 +451,8 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun listUnspent(id: String, result: Promise) {
-        try {
-            Thread {
+        Thread {
+            try {
                 val unspentList = getWalletById(id).listUnspent()
                 val unpents: MutableList<Map<String, Any?>> = mutableListOf()
                 for (item in unspentList) {
@@ -464,10 +464,10 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
                     unpents.add(unspentObject)
                 }
                 result.resolve(Arguments.makeNativeArray(unpents))
-            }.start()
-        } catch (error: Throwable) {
-            result.reject("List unspent outputs error", error.localizedMessage, error)
-        }
+            } catch (error: Throwable) {
+                result.reject("List unspent outputs error", error.localizedMessage, error)
+            }
+        }.start()
     }
 
     @ReactMethod

--- a/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
+++ b/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
@@ -556,7 +556,11 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun addressAsString(id: String, result: Promise) {
-        result.resolve(_addresses[id]!!.asString())
+        try {
+            result.resolve(_addresses[id]!!.asString())
+        } catch (error: Throwable) {
+            result.reject("Couldn't parse address string", error.localizedMessage, error)
+        }
     }
 
     /** Address methods ends*/


### PR DESCRIPTION
Note this PR is build upon: https://github.com/LtbLightning/bdk-rn/pull/64

I received many handfuls of this error. To mitigate this issue I added a `try-catch` block

```
Fatal Exception: java.lang.NullPointerException:
       at io.ltbl.bdkrn.BdkRnModule.addressAsString(BdkRnModule.java:16)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.bridge.JavaMethodWrapper.invoke(:148)
       at com.facebook.react.bridge.JavaModuleWrapper.invoke(:147)
       at com.facebook.jni.NativeRunnable.run(SourceFile)
       at android.os.Handler.handleCallback(Handler.java:958)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage()
       at android.os.Looper.loopOnce(Looper.java:205)
       at android.os.Looper.loop(Looper.java:294)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(:37)
       at java.lang.Thread.run(Thread.java:1012)
```